### PR TITLE
contents(opensuse): normalize the spelling

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -168,7 +168,7 @@ export default function HomePage() {
             <Link href="/opensuse/" className={styles('card')}>
               <IconOpenSUSE className={styles('brand_icon')} />
               <h3 className={styles('card_title')}>
-                OpenSUSE 软件仓库镜像使用帮助
+                openSUSE 软件仓库镜像使用帮助
               </h3>
             </Link>
             <Link href="/centos/" className={styles('card')}>


### PR DESCRIPTION
> **openSUSE** is the only correct way to spell openSUSE.
> [https://en.opensuse.org/Help:Style#openSUSE_spelling](https://en.opensuse.org/Help:Style#openSUSE_spelling)