### PR TITLE
Fix influxdata GPG key URL and filename (and typo fix)

### DIFF
--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -1,6 +1,8 @@
 name: AutoCorrect
 
-on: [pull_request_target]
+on:
+  pull_request:
+    branches: [master]
 
 permissions:
   pull-requests: read
@@ -12,8 +14,6 @@ jobs:
     steps:
     - name: Check source code
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: AutoCorrect check
       run: |

--- a/contents/influxdata.mdx
+++ b/contents/influxdata.mdx
@@ -11,7 +11,7 @@ cname: 'influxdata'
 
 <CodeBlock>
 ```shell
-curl -s https://repos.influxdata.com/influxdb.key | {{sudo}}apt-key add -
+curl -s https://repos.influxdata.com/influxdata-archive_compat.key | {{sudo}}apt-key add -
 ```
 </CodeBlock>
 
@@ -75,7 +75,7 @@ name = InfluxDB Repository - RHEL $releasever
 baseurl={{http_protocol}}{{mirror}}/yum/{{release_name}}
 enabled=1
 gpgcheck=1
-gpgkey={{http_protocol}}{{mirror}}/influxdb.key
+gpgkey=https://repos.influxdata.com/influxdata-archive_compat.key
 ```
 
 </CodeBlock>

--- a/contents/influxdata.mdx
+++ b/contents/influxdata.mdx
@@ -52,7 +52,7 @@ deb {{http_protocol}}{{mirror}}/{{os_name}}/ {{release_name}} stable
 ```
 </CodeBlock>
 
-### Centos / Redhat 用户
+### CentOS / RedHat 用户
 
 新建 `/etc/yum.repos.d/influxdb.repo`，内容为
 


### PR DESCRIPTION
InfluxData's GPG key got rotated recently, see <https://www.influxdata.com/blog/linux-package-signing-key-rotation/>. And the filename has changed to `influxdata-archive_compat.key`.

Also, the help docs for CentOS / RedHat in influxdata.mdx:

- They don't correctly spell "CentOS" and "RedHat".
- They use mirrored GPG key in configuration, which is considered not secure.