### PR TITLE
Fix Link URL in EPEL Doc

### DIFF
--- a/contents/epel.mdx
+++ b/contents/epel.mdx
@@ -21,7 +21,7 @@ EPEL(Extra Packages for Enterprise Linux) 是由 Fedora Special Interest Group �
 
 接下来，取消注释这个文件里`baseurl`开头的行，并将其中的`http://download.fedoraproject.org/pub/epel`替换成`{{http_protocol}}{{mirror}}`。
 
-可以用如下命令自动替换：（来自 https://github.com/tuna/issues/issues/687） 
+可以用如下命令自动替换：（来自 https://github.com/tuna/issues/issues/687 ） 
 
 <CodeBlock>
 

--- a/contents/epel.mdx
+++ b/contents/epel.mdx
@@ -21,7 +21,7 @@ EPEL(Extra Packages for Enterprise Linux) 是由 Fedora Special Interest Group �
 
 接下来，取消注释这个文件里`baseurl`开头的行，并将其中的`http://download.fedoraproject.org/pub/epel`替换成`{{http_protocol}}{{mirror}}`。
 
-可以用如下命令自动替换：（来自 https://github.com/tuna/issues/issues/687 ） 
+可以用如下命令自动替换：（来自 [https://github.com/tuna/issues/issues/687](https://github.com/tuna/issues/issues/687)） 
 
 <CodeBlock>
 


### PR DESCRIPTION
在括号前留空格，防止括号被识别为链接的一部分

![bug](https://user-images.githubusercontent.com/16241583/221514110-9ff83dd7-882a-4ec4-9010-b07b8cfb6562.jpg)
