### PR TITLE
non-free-firmware only for bookworm/testing/sid in debian security

### DIFF
--- a/contents/debian-security.mdx
+++ b/contents/debian-security.mdx
@@ -10,13 +10,13 @@ cname: 'debian-security'
     {
       title: 'Debian 版本',
       items: [
-        ['Debian 11 (bullseye)', { release_name: 'bullseye', security: '-security', is_sid: '', has_backports: '' }],
-        ['Debian 12 (bookworm)', { release_name: 'bookworm', security: '-security', is_sid: '', has_backports: '' }],
-        ['sid', { release_name: 'sid', security: '-security', is_sid: '# ', has_backports: '# ' }],
-        ['testing', { release_name: 'testing', security: '-security', is_sid: '', has_backports: '' }],
-        ['Debian 10 (buster)', { release_name: 'buster', security: '/updates', is_sid: '', has_backports: '' }],
-        ['Debian 9 (stretch)', { release_name: 'stretch', security: '/updates', is_sid: '', has_backports: '' }],
-        ['Debian 8 (jessie)', { release_name: 'jessie', security: '/updates', is_sid: '', has_backports: '# ' }]
+        ['Debian 11 (bullseye)', { release_name: 'bullseye', security: '-security', is_sid: '', has_backports: '', has_nfw: ''  }],
+        ['Debian 12 (bookworm)', { release_name: 'bookworm', security: '-security', is_sid: '', has_backports: '', has_nfw: ' non-free-firmware'  }],
+        ['sid', { release_name: 'sid', security: '-security', is_sid: '# ', has_backports: '# ', has_nfw: ' non-free-firmware'  }],
+        ['testing', { release_name: 'testing', security: '-security', is_sid: '', has_backports: '', has_nfw: ' non-free-firmware'  }],
+        ['Debian 10 (buster)', { release_name: 'buster', security: '/updates', is_sid: '', has_backports: '', has_nfw: ''  }],
+        ['Debian 9 (stretch)', { release_name: 'stretch', security: '/updates', is_sid: '', has_backports: '', has_nfw: ''  }],
+        ['Debian 8 (jessie)', { release_name: 'jessie', security: '/updates', is_sid: '', has_backports: '# ', has_nfw: ''  }]
       ]
     },
     {
@@ -31,8 +31,8 @@ cname: 'debian-security'
 
 ```properties
 # 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
-{{is_sid}}deb {{http_protocol}}{{mirror}} {{release_name}}{{security}} main contrib non-free non-free-firmware
-{{is_sid}}{{enable_source}}deb-src {{http_protocol}}{{mirror}} {{release_name}}{{security}} main contrib non-free non-free-firmware
+{{is_sid}}deb {{http_protocol}}{{mirror}} {{release_name}}{{security}} main contrib non-free{{has_nfw}}
+{{is_sid}}{{enable_source}}deb-src {{http_protocol}}{{mirror}} {{release_name}}{{security}} main contrib non-free{{has_nfw}}
 ```
 
 </CodeBlock>


### PR DESCRIPTION
non-free-firmware only for bookworm/testing/sid in debian security