### PR TITLE
contents(nixpkgs.git): add nixpkgs.git help

### DIFF
--- a/contents/nixpkgs.git.mdx
+++ b/contents/nixpkgs.git.mdx
@@ -1,0 +1,18 @@
+---
+title: Nixpkgs 镜像使用帮助
+cname: 'nixpkgs.git'
+---
+
+nixpkgs 镜像，同步源为 [https://github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs).
+
+### 克隆仓库
+
+<CodeBlock>
+
+```bash
+git clone {{http_protocol}}{{mirror}}/
+  
+```
+
+</CodeBlock>
+

--- a/src/routes.json
+++ b/src/routes.json
@@ -581,6 +581,12 @@
     "file": "nix-channels.mdx",
     "cname": "nix-channels"
   },
+  "/nixpkgs.git/": {
+    "title": "Nixpkgs Git",
+    "fullTitle": "Nixpkgs Git 镜像使用帮助",
+    "file": "nixpkgs.git.mdx",
+    "cname": "nixpkgs.git"
+  },
   "/nixos-images/": {
     "title": "NixOS Images",
     "fullTitle": "NixOS Images 镜像使用帮助",


### PR DESCRIPTION
added basic usage for `nixpkgs.git` so users won't be confused by a 404 page at https://mirrors.tuna.tsinghua.edu.cn/help/nixpkgs.git/