### PR TITLE
Update debian.mdx to select Debian 12 by default

### DIFF
--- a/contents/debian.mdx
+++ b/contents/debian.mdx
@@ -20,8 +20,8 @@ Debian Buster 以上版本默认支持 HTTPS 源。如果遇到无法拉取 HTTP
     {
       title: 'Debian 版本',
       items: [
-        ['Debian 11 (bullseye)', { release_name: 'bullseye', security: '-security', is_sid: '', has_backports: '', has_nfw: '' }],
         ['Debian 12 (bookworm)', { release_name: 'bookworm', security: '-security', is_sid: '', has_backports: '', has_nfw: ' non-free-firmware' }],
+        ['Debian 11 (bullseye)', { release_name: 'bullseye', security: '-security', is_sid: '', has_backports: '', has_nfw: '' }],
         ['sid', { release_name: 'sid', security: '-security', is_sid: '# ', has_backports: '# ', has_nfw: ' non-free-firmware' }],
         ['testing', { release_name: 'testing', security: '-security', is_sid: '', has_backports: '', has_nfw: ' non-free-firmware' }],
         ['Debian 10 (buster)', { release_name: 'buster', security: '/updates', is_sid: '', has_backports: '', has_nfw: '' }],


### PR DESCRIPTION
Move Debian 12 to the first position to make it the default selection for the latest stable version (Debian 12)
