### PR TITLE
contents(homebrew): general updates

### DIFF
--- a/contents/homebrew.mdx
+++ b/contents/homebrew.mdx
@@ -7,11 +7,11 @@ cname: 'homebrew'
 
 镜像站提供了 https://github.com/Homebrew 组织下的以下 `repo`：`brew`, `homebrew-core`, `homebrew-cask`, `homebrew-cask-fonts`, `homebrew-cask-versions`, `homebrew-command-not-found`, `install`。
 
-_注：自brew 3.3.0 (2021 年 10 月 25日) 起，Linuxbrew 核心仓库 `linuxbrew-core` 已被弃用。Linuxbrew 用户应迁移至 `homebrew-core`，并请依本镜像使用帮助重新设置镜像。具体请参阅本帮助 `Linuxbrew 镜像迁移说明` 章节。_
+_注：自 brew 3.3.0 (2021 年 10 月 25 日) 起，Linuxbrew 核心仓库 `linuxbrew-core` 已被弃用。Linuxbrew 用户应迁移至 `homebrew-core`，并请依本镜像使用帮助重新设置镜像。具体请参阅本帮助 `Linuxbrew 镜像迁移说明` 章节。_
 
-_注：自brew 4.0.0 (2023 年 2 月 16日) 起，`HOMEBREW_INSTALL_FROM_API` 会成为默认行为，无需设置。大部分用户无需再克隆 `homebrew-core` 仓库，故无需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量；但若需要运行 `brew` 的开发命令或者 `brew` 安装在非官方支持的默认 prefix 位置，则仍需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量。如果不想通过 API 安装，可以设置 `HOMEBREW_NO_INSTALL_FROM_API=1`。_
+_注：自 brew 4.0.0 (2023 年 2 月 16 日) 起，`HOMEBREW_INSTALL_FROM_API` 会成为默认行为，无需设置。大部分用户无需再克隆 `homebrew-core` 仓库，故无需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量；但若需要运行 `brew` 的开发命令或者 `brew` 安装在非官方支持的默认 prefix 位置，则仍需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量。如果不想通过 API 安装，可以设置 `HOMEBREW_NO_INSTALL_FROM_API=1`。_
 
-_注：自brew 4.0.22 (2023 年 6 月 12 日) 起，`homebrew-cask-drivers` 已被弃用，所有 cask 合并至 `homebrew-cask` 仓库。本帮助内已移除克隆 `homebrew-cask-drivers` 仓库的命令。已克隆用户可选择运行 `brew untap homebrew/cask-drivers` 命令移除此仓库。_
+_注：自 brew 4.0.22 (2023 年 6 月 12 日) 起，`homebrew-cask-drivers` 已被弃用，所有 cask 合并至 `homebrew-cask` 仓库。本帮助内已移除克隆 `homebrew-cask-drivers` 仓库的命令。已克隆用户可选择运行 `brew untap homebrew/cask-drivers` 命令移除此仓库。_
 
 ### 首次安装 Homebrew / Linuxbrew
 

--- a/contents/homebrew.mdx
+++ b/contents/homebrew.mdx
@@ -5,7 +5,13 @@ cname: 'homebrew'
 
 **注：该镜像是 Homebrew / Linuxbrew 源程序以及 formula / cask 索引的镜像（即 `brew update` 时所更新内容）。镜像站同时提供相应的二进制预编译包的镜像，请参考 [Homebrew bottles 镜像使用帮助](/homebrew-bottles/)**
 
-镜像站提供了 https://github.com/Homebrew 组织下的以下 `repo`：`brew`, `homebrew-core`, `homebrew-cask`, `homebrew-cask-fonts`, `homebrew-cask-drivers`, `homebrew-cask-versions`, `homebrew-command-not-found`, `install`。
+镜像站提供了 https://github.com/Homebrew 组织下的以下 `repo`：`brew`, `homebrew-core`, `homebrew-cask`, `homebrew-cask-fonts`, `homebrew-cask-versions`, `homebrew-command-not-found`, `install`。
+
+_注：自brew 3.3.0 (2021 年 10 月 25日) 起，Linuxbrew 核心仓库 `linuxbrew-core` 已被弃用。Linuxbrew 用户应迁移至 `homebrew-core`，并请依本镜像使用帮助重新设置镜像。具体请参阅本帮助 `Linuxbrew 镜像迁移说明` 章节。_
+
+_注：自brew 4.0.0 (2023 年 2 月 16日) 起，`HOMEBREW_INSTALL_FROM_API` 会成为默认行为，无需设置。大部分用户无需再克隆 `homebrew-core` 仓库，故无需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量；但若需要运行 `brew` 的开发命令或者 `brew` 安装在非官方支持的默认 prefix 位置，则仍需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量。如果不想通过 API 安装，可以设置 `HOMEBREW_NO_INSTALL_FROM_API=1`。_
+
+_注：自brew 4.0.22 (2023 年 6 月 12 日) 起，`homebrew-cask-drivers` 已被弃用，所有 cask 合并至 `homebrew-cask` 仓库。本帮助内已移除克隆 `homebrew-cask-drivers` 仓库的命令。已克隆用户可选择运行 `brew untap homebrew/cask-drivers` 命令移除此仓库。_
 
 ### 首次安装 Homebrew / Linuxbrew
 
@@ -108,14 +114,13 @@ brew tap --custom-remote --force-auto-update homebrew/cask {{http_protocol}}{{mi
 
 # 除 homebrew/core 和 homebrew/cask 仓库外的 tap 仓库仍然需要设置镜像
 brew tap --custom-remote --force-auto-update homebrew/cask-fonts {{http_protocol}}{{mirror}}/homebrew-cask-fonts.git
-brew tap --custom-remote --force-auto-update homebrew/cask-drivers {{http_protocol}}{{mirror}}/homebrew-cask-drivers.git
 brew tap --custom-remote --force-auto-update homebrew/cask-versions {{http_protocol}}{{mirror}}/homebrew-cask-versions.git
 brew tap --custom-remote --force-auto-update homebrew/command-not-found {{http_protocol}}{{mirror}}/homebrew-command-not-found.git
 brew update
 
 # 或使用下面的几行命令自动设置
 export HOMEBREW_CORE_GIT_REMOTE="{{http_protocol}}{{mirror}}/homebrew-core.git"
-for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
+for tap in core cask{,-fonts,-versions} command-not-found; do
     brew tap --custom-remote --force-auto-update "homebrew/${tap}" "{{http_protocol}}{{mirror}}/homebrew-${tap}.git"
 done
 brew update
@@ -160,7 +165,9 @@ test -r ~/.zprofile && echo 'export HOMEBREW_CORE_GIT_REMOTE="{{http_protocol}}{
 
 对于 `HOMEBREW_API_DOMAIN` 与其余 bottles 相关环境变量的持久化，可以参考 [Homebrew Bottles 帮助](/homebrew-bottles/)。
 
-_镜像迁移说明：Linuxbrew 核心仓库（`linuxbrew-core`）自 2021 年 10 月 25 日（`brew` 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 `homebrew-core`。Linuxbrew 用户请依新版镜像说明重新设置镜像。注意迁移前请先运行 `brew update` 将 `brew` 更新至 3.3.0 或以上版本。迁移过程中若出现任何问题，可使用如下命令重新安装 `homebrew-core`：_
+### Linuxbrew 镜像迁移说明
+
+Linuxbrew 核心仓库（`linuxbrew-core`）自 2021 年 10 月 25 日（`brew` 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 `homebrew-core`。Linuxbrew 用户请依新版镜像说明重新设置镜像。注意迁移前请先运行 `brew update` 将 `brew` 更新至 3.3.0 或以上版本。迁移过程中若出现任何问题，可使用如下命令重新安装 `homebrew-core`：
 
 <CodeBlock>
 
@@ -175,6 +182,10 @@ brew tap --custom-remote --force-auto-update homebrew/core {{http_protocol}}{{mi
 ### 复原仓库上游
 
 _(感谢 Snowonion Lee 提供说明)_
+
+- 以下针对 macOS 系统上的 Homebrew
+
+<CodeBlock>
 
 ```bash
 # brew 程序本身，Homebrew / Linuxbrew 相同
@@ -191,6 +202,22 @@ for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
     fi
 done
 
+# 重新拉取远程
+brew update
+```
+
+</CodeBlock>
+
+- 以下针对 Linux 系统上的 Linuxbrew
+
+<CodeBlock>
+
+```bash
+# brew 程序本身，Homebrew / Linuxbrew 相同
+unset HOMEBREW_API_DOMAIN
+unset HOMEBREW_BREW_GIT_REMOTE
+git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
+
 # 以下针对 Linux 系统上的 Linuxbrew
 unset HOMEBREW_API_DOMAIN
 unset HOMEBREW_CORE_GIT_REMOTE
@@ -200,5 +227,7 @@ brew tap --custom-remote homebrew/command-not-found https://github.com/Homebrew/
 # 重新拉取远程
 brew update
 ```
+
+</CodeBlock>
 
 **注：重置回默认远程后，用户应该删除 shell 的 profile 设置中的环境变量 `HOMEBREW_BREW_GIT_REMOTE` 和 `HOMEBREW_CORE_GIT_REMOTE` 以免运行 `brew update` 时远程再次被更换。**


### PR DESCRIPTION
* Support for homebrew-cask-drivers repo has been removed since brew version 4.0.22, therefore any command-line settings related to that repo will report an error and thus should be removed.
  * Error log: `Error: homebrew/cask-drivers was deprecated. This tap is now empty and all its contents were either deleted or migrated.`
  * Ref: Homebrew/brew#15535
* Pinned warnings about mirror site changes
* Separated codeblocks that were co-used by Homebrew and Linuxbrew

The original PR was created at tuna/mirror-web#377 that also contained changes regarding homebrew-services repo. However, considering few mirror sites has supported that repo, those changes are not included in this PR. Discuss if needed.