### PR TITLE
依照上游修改 docker-ce 的帮助文档

### DIFF
--- a/contents/docker-ce.mdx
+++ b/contents/docker-ce.mdx
@@ -26,7 +26,7 @@ wget -O- https://get.docker.com/ | {{sudoE}}sh
 
 </CodeBlock>
 
-### Debian/Ubuntu 用户
+### Debian/Ubuntu/Raspbian 用户
 
 以下内容根据 [官方文档](https://docs.docker.com/engine/install/debian/) 修改而来。
 
@@ -34,7 +34,7 @@ wget -O- https://get.docker.com/ | {{sudoE}}sh
 
 <CodeBlock>
 ```bash
-{{sudo}}apt-get remove docker docker-engine docker.io containerd runc
+for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do {{sudo}}apt-get remove $pkg; done
 ```
 </CodeBlock>
 
@@ -42,6 +42,7 @@ wget -O- https://get.docker.com/ | {{sudoE}}sh
 
 <CodeBlock>
 ```bash
+{{sudo}}apt-get update
 {{sudo}}apt-get install ca-certificates curl gnupg
 ```
 </CodeBlock>
@@ -55,6 +56,7 @@ wget -O- https://get.docker.com/ | {{sudoE}}sh
       items: [
         ['Debian', { deb_release: 'debian' }],
         ['Ubuntu', { deb_release: 'ubuntu' }],
+        ['Raspbian', { deb_release: 'raspbian' }],
       ]
     }
   ]}
@@ -63,11 +65,12 @@ wget -O- https://get.docker.com/ | {{sudoE}}sh
 ```bash
 {{sudo}}install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/{{deb_release}}/gpg | {{sudo}}gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{http_protocol}}{{mirror}}/linux/{{deb_release}} \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | {{sudo}}tee /etc/apt/sources.list.d/docker.list > /dev/null
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  {{sudo}}tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
-
 </CodeBlock>
 
 最后安装
@@ -75,11 +78,52 @@ echo \
 <CodeBlock>
 ```bash
 {{sudo}}apt-get update
-{{sudo}}apt-get install docker-ce
+{{sudo}}apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 </CodeBlock>
 
-### Fedora/CentOS/RHEL
+### Fedora
+
+以下内容根据 [官方文档](https://docs.docker.com/engine/install/fedora/) 修改而来。
+
+如果你之前安装过 docker，请先删掉
+
+<CodeBlock>
+```bash
+{{sudo}}dnf remove docker \
+                  docker-client \
+                  docker-client-latest \
+                  docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
+                  docker-selinux \
+                  docker-engine-selinux \
+                  docker-engine
+```
+</CodeBlock>
+
+
+安装依赖，下载 repo 文件，并把软件仓库地址替换为镜像站：
+
+<CodeBlock>
+```bash
+{{sudo}}dnf -y install dnf-plugins-core
+{{sudo}}dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+{{sudo}}sed -i 's+https://download.docker.com+{{http_protocol}}{{mirror}}+' /etc/yum.repos.d/docker-ce.repo
+```
+
+</CodeBlock>
+
+最后安装：
+
+<CodeBlock>
+```bash
+{{sudo}}dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+</CodeBlock>
+
+### CentOS/RHEL
 
 以下内容根据 [官方文档](https://docs.docker.com/engine/install/centos/) 修改而来。
 
@@ -87,33 +131,33 @@ echo \
 
 <CodeBlock>
 ```bash
-{{sudo}}yum remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotate docker-engine
+{{sudo}}yum remove docker \
+                  docker-client \
+                  docker-client-latest \
+                  docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
+                  docker-engine
 ```
 </CodeBlock>
 
-安装一些依赖
-
-<CodeBlock>
-```bash
-{{sudo}}yum install -y yum-utils device-mapper-persistent-data lvm2
-```
-</CodeBlock>
-
-下载 repo 文件，并把软件仓库地址替换为镜像站：
+安装依赖，下载 repo 文件，并把软件仓库地址替换为镜像站：
 
 <CodeBlock
   menus={[
     {
       title: '发行版',
       items: [
-        ['CentOS/RHEL', { yum_release: 'centos' }],
-        ['Fedora', { yum_release: 'fedora' }],
+        ['CentOS', { yum_release: 'centos' }],
+        ['RHEL', { yum_release: 'rhel' }],
       ]
     }
   ]}
 >
 
 ```bash
+{{sudo}} yum install -y yum-utils
 yum-config-manager --add-repo https://download.docker.com/linux/{{yum_release}}/docker-ce.repo
 {{sudo}}sed -i 's+https://download.docker.com+{{http_protocol}}{{mirror}}+' /etc/yum.repos.d/docker-ce.repo
 ```
@@ -124,8 +168,7 @@ yum-config-manager --add-repo https://download.docker.com/linux/{{yum_release}}/
 
 <CodeBlock>
 ```bash
-{{sudo}}yum makecache fast
-{{sudo}}yum install docker-ce
+{{sudo}}yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 </CodeBlock>
 


### PR DESCRIPTION
依照 docker 官方文档做出修改
+ debian/ubuntu 部分添加 raspbian 的帮助
+ 把 fedora 部分独立出来
+ centos/rhel 部分中把 centos 和 rhel 分开

> Ref:  https://docs.docker.com/engine/install/debian/
> https://docs.docker.com/engine/install/raspbian/
> https://docs.docker.com/engine/install/fedora/