### PR TITLE
Update ROS2 document

### DIFF
--- a/contents/ros2.mdx
+++ b/contents/ros2.mdx
@@ -20,6 +20,7 @@ cname: 'ros2'
         ['Ubuntu 22.04 LTS', { release_name: 'jammy' }],
         ['Ubuntu 20.04 LTS', { release_name: 'focal' }],
         ['Ubuntu 18.04 LTS', { release_name: 'bionic' }],
+        ['Debian 12 (bookworm)', { release_name: 'bookworm' }],
         ['Debian 11 (bullseye)', { release_name: 'bullseye' }],
         ['Debian 10 (buster)', { release_name: 'buster' }],
       ]
@@ -35,7 +36,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-a
 
 </CodeBlock>
 
-Reference: https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+Reference: https://docs.ros.org/en/iron/Installation/Ubuntu-Install-Debians.html
 
 ### rosdep
 


### PR DESCRIPTION
- add debian 12 (bookworm) distribution
- update reference link to latest release of ROS2