### PR TITLE
fix(crates.io-index): config file path error when install rust without default CARGO_HOME environment variable

### DIFF
--- a/contents/crates.io-index.git.mdx
+++ b/contents/crates.io-index.git.mdx
@@ -3,7 +3,7 @@ title: Rust crates.io 索引镜像使用帮助
 cname: 'crates.io-index.git'
 ---
 
-编辑 `~/.cargo/config` 文件，添加以下内容：
+编辑 `$CARGO_HOME/config` 文件，添加以下内容：
 
 <CodeBlock>
 
@@ -13,6 +13,26 @@ replace-with = 'mirror'
 
 [source.mirror]
 registry = "{{http_protocol}}{{mirror}}"
+```
+
+</CodeBlock>
+
+注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`
+
+在 Linux 环境可以使用下面的命令完成：
+
+<CodeBlock>
+
+```bash
+mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
+
+cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+[source.crates-io]
+replace-with = 'mirror'
+
+[source.mirror]
+registry = "{{http_protocol}}{{mirror}}"
+EOF
 ```
 
 </CodeBlock>

--- a/contents/crates.io-index.mdx
+++ b/contents/crates.io-index.mdx
@@ -4,7 +4,7 @@ cname: 'crates.io-index'
 disable_https_select: true
 ---
 
-编辑 `~/.cargo/config` 文件，添加以下内容：
+编辑 `$CARGO_HOME/config` 文件，添加以下内容：
 
 <CodeBlock>
 
@@ -19,6 +19,26 @@ registry = "sparse+{{http_protocol}}{{mirror}}/"
 </CodeBlock>
 
 注：`sparse+` 表示在使用稀疏索引，链接末尾的 `/` 不能缺少。
+
+注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`
+
+在 Linux 环境可以使用下面的命令完成：
+
+<CodeBlock>
+
+```bash
+mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
+
+cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+[source.crates-io]
+replace-with = 'mirror'
+
+[source.mirror]
+registry = "sparse+{{http_protocol}}{{mirror}}/"
+EOF
+```
+
+</CodeBlock>
 
 截至目前，可以通过 `cargo +nightly -Z sparse-registry update` 使用稀疏索引。
 


### PR DESCRIPTION
Ref : [https://github.com/ustclug/mirrorhelp/pull/230](https://github.com/ustclug/mirrorhelp/pull/230)