### PR TITLE
CRAN: follow upstream doc for key verification

### DIFF
--- a/contents/CRAN.mdx
+++ b/contents/CRAN.mdx
@@ -93,9 +93,11 @@ deb {{http_protocol}}{{mirror}}/bin/linux/{{os_name}} {{release_name}}-{{version
 <CodeBlock>
 ```bash
 # Debian 用户添加该公钥
-{{sudo}}apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
+gpg --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
+gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | {{sudo}} tee /etc/apt/trusted.gpg.d/cran_debian_key.asc
 # Ubuntu 用户添加该公钥
-{{sudo}}apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+wget -qO- {{http_protocol}}{{mirror}}/bin/linux/ubuntu/marutter_pubkey.asc | {{sudo}} tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+# 更新软件包
 {{sudo}}apt-get update
 {{sudo}}apt-get install r-base-dev
 ```


### PR DESCRIPTION
Ported from https://github.com/mirrorz-org/mirrorz-docs/pull/3

`apt-key` is deprecated, updating to `gpg`