### PR TITLE
同步 Ubuntu 生命周期

### DIFF
--- a/contents/ubuntu-ports.mdx
+++ b/contents/ubuntu-ports.mdx
@@ -14,9 +14,10 @@ Ubuntu 的软件源配置文件是 `/etc/apt/sources.list`。将系统自带的�
     {
       title: 'Ubuntu 版本',
       items: [
-        ['22.04 LTS', { release_name: 'jammy' }],
+        ['24.04 LTS', { release_name: 'noble' }],
         ['23.10', { release_name: 'mantic' }],
         ['23.04', { release_name: 'lunar' }],
+        ['22.04 LTS', { release_name: 'jammy' }],
         ['20.04 LTS', { release_name: 'focal' }],
         ['18.04 LTS', { release_name: 'bionic' }],
         ['16.04 LTS', { release_name: 'xenial' }],

--- a/contents/ubuntu.mdx
+++ b/contents/ubuntu.mdx
@@ -16,9 +16,10 @@ Ubuntu 的软件源配置文件是 `/etc/apt/sources.list`。将系统自带的�
     {
       title: 'Ubuntu 版本',
       items: [
-        ['22.04 LTS', { release_name: 'jammy' }],
+        ['24.04 LTS', { release_name: 'noble' }],
         ['23.10', { release_name: 'mantic' }],
         ['23.04', { release_name: 'lunar' }],
+        ['22.04 LTS', { release_name: 'jammy' }],
         ['20.04 LTS', { release_name: 'focal' }],
         ['18.04 LTS', { release_name: 'bionic' }],
         ['16.04 LTS', { release_name: 'xenial' }],


### PR DESCRIPTION
添加 Ubuntu 24.04 LTS 至 ubuntu 和 ubuntu-ports