### PR TITLE
Fix wrong option (and I believe a typo) for nixos-rebuild

### DIFF
--- a/contents/nix-channels.mdx
+++ b/contents/nix-channels.mdx
@@ -73,7 +73,7 @@ nixos-rebuild --option substituters "{{http_protocol}}{{mirror}}/store"
 临时关闭可以通过清空 substituters 实现：
 
 ```shell
-nixos-rebuild --options substituters ""
+nixos-rebuild --option substituters ""
 ```
 
 ### Nixpkgs channel


### PR DESCRIPTION
All other `nixos-rebuild` command on this page use (I believe) the correct `--option` except this one.

passing `--options` to `nix` command here on my system will result in

> error: unrecognised flag '--options'

I have only macOS at the moment, so this is just a guess and you should test it before accepting this change.