### PR TITLE
 Modify Hackage and GHCup contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 node_modules
 .idea
+.vscode
 .directory
 dist
 .next

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -86,7 +86,7 @@ url-source:
 
 ### 使用说明
 
-创建 `~/.ghcup/config.yaml` 并输入以下内容
+创建 `~/.ghcup/config.yaml` 并输入以下内容：
 
 <CodeBlock>
 
@@ -99,7 +99,7 @@ url-source:
 
 如果您尚未安装 ghcup，请在完成以上步骤后，于终端中执行以下指令（请不要以 root 用户执行），随后跟随屏幕上的指引完成安装。
 
-- 如果您运行的是 Linux, macOS (Intel), FreeBSD 或 WSL，请执行
+- 如果您运行的是 Linux, macOS (Intel), FreeBSD 或 WSL，请执行：
 
 <CodeBlock>
 
@@ -109,7 +109,7 @@ curl --proto '=https' --tlsv1.2 -LsSf https://{{mirror}}/script/install.sh | sh
 
 </CodeBlock>
 
-- 如果您运行的是 macOS (Apple 芯片) 请执行
+- 如果您运行的是 macOS (Apple 芯片) 请执行：
 
 <CodeBlock>
 
@@ -141,13 +141,15 @@ ghcup 于 0.1.15.1 版本前使用 0.0.4 版本的配置文件，此版本及之
 
 ### XDG 支持
 
+参考 [GHCup xdg-support](https://www.haskell.org/ghcup/guide/#xdg-support)。
+
 对于 Linux、FreeBSD、macOS 用户，如果想要让 GHCup 遵循 XDG 规范，可以使用 `GHCUP_USE_XDG_DIRS` 变量，例如：
 
 ```bash
 export GHCUP_USE_XDG_DIRS=1
 ```
 
-还可以将上述内容写入 `~/.profile` 等文件中，具体可以参考 [GHCup xdg-support](https://www.haskell.org/ghcup/guide/#xdg-support)。
+还可以将上述内容写入 `~/.profile` 等文件中。
 
 使用 `GHCUP_USE_XDG_DIRS` 后，GHCup 配置目录将由默认的 `~/.ghcup` 变成 `~/.config/ghcup`；
 而二进制目录会使用 `~/.local/bin`，需要将该目录加入 `PATH` 才能够正常使用 GHCup 安装的 GHC 以及其他工具。
@@ -158,35 +160,36 @@ export PATH=$HOME/.local/bin:$PATH
 
 ### 安装目录变更
 
-对于 Windows 用户或不想使用 XDG 目录的 Linux、FreeBSD、macOS 用户，可以使用 `GHCUP_INSTALL_BASE_PREFIX` 来更改默认安装路径。
+参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。
 
+对于 Windows 用户或不想使用 XDG 目录的 Linux、FreeBSD、macOS 用户，可以使用 `GHCUP_INSTALL_BASE_PREFIX` 来更改默认安装路径。
 默认安装路径，对 Windows 用户而言是 `C:\ghcup`，而对于 Linux、FreeBSD、macOS 用户而言是 `$HOME/.ghcup`。
 
-如果想要将 GHCup 的安装目录放到某一个特定目录下，例如 `~/sdk`，则可以使用
+如果想要将 GHCup 的安装目录放到某一个特定目录下，例如 `~/sdk`：
 
-**Windows 用户**:
+- **Windows 用户**
 
-可以在终端使用如下方法：
+  可以在终端使用如下方法：
 
-```powershell
-$env:GHCUP_INSTALL_BASE_PREFIX = $env:USERPROFILE/sdk
-```
+  ```powershell
+  $env:GHCUP_INSTALL_BASE_PREFIX = $env:USERPROFILE/sdk
+  ```
 
-或使用系统设置添加该环境变量。
+  或使用系统设置添加该环境变量。
 
-**Linux、FreeBSD、macOS 用户**:
+- **Linux、FreeBSD、macOS 用户**
 
-可以在终端使用如下方法：
+  可以在终端使用如下方法：
 
-```bash
-export GHCUP_INSTALL_BASE_PREFIX=$HOME/sdk
-```
+  ```bash
+  export GHCUP_INSTALL_BASE_PREFIX=$HOME/sdk
+  ```
 
-还可以将上述内容写入 `~/.profile` 等文件中，具体可以参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。
+  还可以将上述内容写入 `~/.profile` 等文件中。
 
 ### MSYS2 设置
 
-对于 Windows 用户，如果系统中已经安装了 MSYS2 环境，则可以使用 `GHCUP_MSYS2` 来指定你想要 GHCup 使用的 MSYS2 环境。
-如果不指定使用的 MSYS2 环境，则会默认新安装一个 MSYS2 环境，并且使用新安装的 MSYS2 环境。
+参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。
 
-详细内容可以参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。
+对于 Windows 用户，如果系统中已经安装了 MSYS2 环境，则可以使用 `GHCUP_MSYS2` 来指定想要让 GHCup 使用的 MSYS2 环境。
+如果不指定使用的 MSYS2 环境，则会默认新安装一个 MSYS2 环境，并且使用新安装的 MSYS2 环境。

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -1,11 +1,13 @@
 ---
 title: GHCup 使用帮助
-cname: 'ghcup'
+cname: "ghcup"
 ---
 
 GHCup 是一种用于安装 Haskell 的工具，它使得用户可以轻易地在 GNU/Linux、macOS 和 FreeBSD 上安装特定版本的 ghc，并从零开始搭建好一个全新的 Haskell 开发环境（包括 cabal 与 HLS 支持）。
 
 GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackage 和 Stackage 源使用。
+
+> 如果想要使用 XDG 规范，可以设置 `GHCUP_USE_XDG_DIRS` 变量，例如 `export GHCUP_USE_XDG_DIRS=1`
 
 ## USTC
 
@@ -15,44 +17,35 @@ GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackag
 
 参考如下步骤可安装完整的 Haskell 工具链。
 
-注意，以下命令会安装并配置 GHCup 0.0.7 版本的元数据。
+注意，以下命令会安装并配置 GHCup 0.0.8 版本的元数据。
 可查看以下目录的内容，并选择需要安装的 GHCup 版本的 yaml 文件替换以下命令中的 URL。
 
-<CodeBlock>
 ```
-{{http_protocol}}{{mirror}}/ghcup-metadata/
+https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/
 ```
-</CodeBlock>
-
 
 **第一步（可选）** ：使用镜像源安装 GHCup 本体。如已经安装 GHCup，可跳到下一步。
 
+- Linux, FreeBSD, macOS 用户：在终端中运行如下命令
 
-* Linux, FreeBSD, macOS 用户：在终端中运行如下命令
-
-  <CodeBlock>
   ```bash
-  curl --proto '=https' --tlsv1.2 -sSf https://{{mirror}}/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML={{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.7.yaml sh
+  # Linux, FreeBSD, macOS 用户：在终端中运行如下命令
+  curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML=https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml sh
   ```
-  </CodeBlock>
 
-* Windows 用户：以非管理员身份在 PowerShell 中运行如下命令
+- Windows 用户：以非管理员身份在 PowerShell 中运行如下命令
 
-  <CodeBlock>
   ```powershell
-  $env:BOOTSTRAP_HASKELL_YAML = '{{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.7.yaml'
-  Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest {{http_protocol}}{{mirror}}/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true
+  $env:BOOTSTRAP_HASKELL_YAML = 'https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml'
+  Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true
   ```
-  </CodeBlock>
 
 **第二步** ：配置 GHCup 使用科大源。编辑 `~/.ghcup/config.yaml` 增加如下配置：
 
-<CodeBlock>
 ```yaml
 url-source:
-    OwnSource: {{http_protocol}}{{mirror}}/ghcup/ghcup-metadata/ghcup-0.0.7.yaml
+  OwnSource: https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
 ```
-</CodeBlock>
 
 **第三步（可选）** ：配置 Cabal 和 Stack 使用镜像源，请参考文档 [Hackage 帮助](/hackage/) 和 [Stackage 帮助](stackage) 。
 
@@ -62,14 +55,12 @@ url-source:
 
 使用预发布频道可以安装尚未正式发布的测试版本。要启用预发布源，将 `~/.ghcup/config.yaml` 文件中 `url-source` 一节修改如下：
 
-<CodeBlock>
 ```yaml
 url-source:
-    OwnSource:
-    - {{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.7.yaml
-    - {{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-prereleases-0.0.7.yaml
+  OwnSource:
+    - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
+    - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-prereleases-0.0.8.yaml
 ```
-</CodeBlock>
 
 ## SJTUG
 
@@ -80,10 +71,12 @@ url-source:
 创建 `~/.ghcup/config.yaml` 并输入以下内容
 
 <CodeBlock>
+
 ```yaml
 url-source:
-    OwnSource: "{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.6.yaml"
+  OwnSource: "{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.6.yaml"
 ```
+
 </CodeBlock>
 
 如果您尚未安装 ghcup，请在完成以上步骤后，于终端中执行以下指令（请不要以 root 用户执行），随后跟随屏幕上的指引完成安装。
@@ -91,17 +84,21 @@ url-source:
 - 如果您运行的是 Linux, macOS (Intel), FreeBSD 或 WSL，请执行
 
 <CodeBlock>
+
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://{{mirror}}/script/install.sh | sh
 ```
+
 </CodeBlock>
 
 - 如果您运行的是 macOS (Apple 芯片) 请执行
 
 <CodeBlock>
+
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://{{mirror}}/script/install.sh | arch -x86_64 /bin/bash
 ```
+
 </CodeBlock>
 
 **故障排除**

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -1,6 +1,6 @@
 ---
 title: GHCup 使用帮助
-cname: "ghcup"
+cname: 'ghcup'
 ---
 
 GHCup 是一种用于安装 Haskell 的工具，它使得用户可以轻易地在 GNU/Linux、macOS 和 FreeBSD 上安装特定版本的 ghc，并从零开始搭建好一个全新的 Haskell 开发环境（包括 cabal 与 HLS 支持）。

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -7,7 +7,11 @@ GHCup 是一种用于安装 Haskell 的工具，它使得用户可以轻易地�
 
 GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackage 和 Stackage 源使用。
 
-> 如果想要使用 XDG 规范，可以设置 `GHCUP_USE_XDG_DIRS` 变量，例如 `export GHCUP_USE_XDG_DIRS=1`
+> 如果想要使用 XDG 规范，可以设置 `GHCUP_USE_XDG_DIRS` 变量
+>
+> Linux、BSD、macOS 用户可在终端使用 `export GHCUP_USE_XDG_DIRS=1`
+>
+> Windows 用户可使用 `$env:GHCUP_USE_XDG_DIRS = 1`
 
 ## USTC
 
@@ -20,32 +24,48 @@ GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackag
 注意，以下命令会安装并配置 GHCup 0.0.8 版本的元数据。
 可查看以下目录的内容，并选择需要安装的 GHCup 版本的 yaml 文件替换以下命令中的 URL。
 
+<CodeBlock>
+
 ```
-https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/
+{{http_protocol}}{{mirror}}/ghcup-metadata/
 ```
+
+</CodeBlock>
 
 **第一步（可选）** ：使用镜像源安装 GHCup 本体。如已经安装 GHCup，可跳到下一步。
 
 - Linux, FreeBSD, macOS 用户：在终端中运行如下命令
 
+  <CodeBlock>
+
   ```bash
   # Linux, FreeBSD, macOS 用户：在终端中运行如下命令
-  curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML=https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml sh
+  curl --proto '=https' --tlsv1.2 -sSf {{http_protocol}}{{mirror}}/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML={{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.8.yaml sh
   ```
+
+  </CodeBlock>
 
 - Windows 用户：以非管理员身份在 PowerShell 中运行如下命令
 
+  <CodeBlock>
+
   ```powershell
-  $env:BOOTSTRAP_HASKELL_YAML = 'https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml'
-  Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true
+  $env:BOOTSTRAP_HASKELL_YAML = '{{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.8.yaml'
+  Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest {{http_protocol}}{{mirror}}/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true
   ```
+
+  </CodeBlock>
 
 **第二步** ：配置 GHCup 使用科大源。编辑 `~/.ghcup/config.yaml` 增加如下配置：
 
+<CodeBlock>
+
 ```yaml
 url-source:
-  OwnSource: https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
+  OwnSource: {{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.8.yaml
 ```
+
+</CodeBlock>
 
 **第三步（可选）** ：配置 Cabal 和 Stack 使用镜像源，请参考文档 [Hackage 帮助](/hackage/) 和 [Stackage 帮助](stackage) 。
 
@@ -55,12 +75,16 @@ url-source:
 
 使用预发布频道可以安装尚未正式发布的测试版本。要启用预发布源，将 `~/.ghcup/config.yaml` 文件中 `url-source` 一节修改如下：
 
+<CodeBlock>
+
 ```yaml
 url-source:
   OwnSource:
-    - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
-    - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-prereleases-0.0.8.yaml
+    - {{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-0.0.8.yaml
+    - {{http_protocol}}{{mirror}}/ghcup-metadata/ghcup-prereleases-0.0.8.yaml
 ```
+
+</CodeBlock>
 
 ## SJTUG
 
@@ -74,7 +98,7 @@ url-source:
 
 ```yaml
 url-source:
-  OwnSource: "{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.8.yaml"
+  OwnSource: '{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.8.yaml'
 ```
 
 </CodeBlock>

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -7,11 +7,13 @@ GHCup 是一种用于安装 Haskell 的工具，它使得用户可以轻易地�
 
 GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackage 和 Stackage 源使用。
 
-> 如果想要使用 XDG 规范，可以设置 `GHCUP_USE_XDG_DIRS` 变量
+> 对于 Linux、FreeBSD、macOS 用户，如果想要让 GHCup 遵循 XDG 规范，可以使用 `GHCUP_USE_XDG_DIRS` 变量，例如：
 >
-> Linux、BSD、macOS 用户可在终端使用 `export GHCUP_USE_XDG_DIRS=1`
+> ```bash
+> export GHCUP_USE_XDG_DIRS=1
+> ```
 >
-> Windows 用户可使用 `$env:GHCUP_USE_XDG_DIRS = 1`
+> 还可以将上述内容写入 `~/.profile` 等文件中。
 
 ## USTC
 

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -7,14 +7,6 @@ GHCup 是一种用于安装 Haskell 的工具，它使得用户可以轻易地�
 
 GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackage 和 Stackage 源使用。
 
-> 对于 Linux、FreeBSD、macOS 用户，如果想要让 GHCup 遵循 XDG 规范，可以使用 `GHCUP_USE_XDG_DIRS` 变量，例如：
->
-> ```bash
-> export GHCUP_USE_XDG_DIRS=1
-> ```
->
-> 还可以将上述内容写入 `~/.profile` 等文件中。
-
 ## USTC
 
 该节内容仅适用于 USTC 及通过类似方式同步 GHCup 的站点。
@@ -144,3 +136,57 @@ ghcup 于 0.1.15.1 版本前使用 0.0.4 版本的配置文件，此版本及之
 当出现上述现象时，请首先尝试更新 ghcup 的版本，并根据 `故障排除 1` 的指示修改配置文件。若 ghcup 已无法更新，可以尝试删除 `~/.ghcup` 整个文件夹（这一操作将删除 ghcup 以及所有通过 ghcup 安装的软件），并根据 `使用说明` 重新安装最新版本的 ghcup。
 
 若完成以上步骤后问题仍未解决，请至 [此处](https://github.com/sjtug/mirror-requests) 向 SJTUG 反馈 BUG。
+
+## 其他配置
+
+### XDG 支持
+
+对于 Linux、FreeBSD、macOS 用户，如果想要让 GHCup 遵循 XDG 规范，可以使用 `GHCUP_USE_XDG_DIRS` 变量，例如：
+
+```bash
+export GHCUP_USE_XDG_DIRS=1
+```
+
+还可以将上述内容写入 `~/.profile` 等文件中，具体可以参考 [GHCup xdg-support](https://www.haskell.org/ghcup/guide/#xdg-support)。
+
+使用 `GHCUP_USE_XDG_DIRS` 后，GHCup 配置目录将由默认的 `~/.ghcup` 变成 `~/.config/ghcup`；
+而二进制目录会使用 `~/.local/bin`，需要将该目录加入 `PATH` 才能够正常使用 GHCup 安装的 GHC 以及其他工具。
+
+```bash
+export PATH=$HOME/.local/bin:$PATH
+```
+
+### 安装目录变更
+
+对于 Windows 用户或不想使用 XDG 目录的 Linux、FreeBSD、macOS 用户，可以使用 `GHCUP_INSTALL_BASE_PREFIX` 来更改默认安装路径。
+
+默认安装路径，对 Windows 用户而言是 `C:\ghcup`，而对于 Linux、FreeBSD、macOS 用户而言是 `$HOME/.ghcup`。
+
+如果想要将 GHCup 的安装目录放到某一个特定目录下，例如 `~/sdk`，则可以使用
+
+**Windows 用户**:
+
+可以在终端使用如下方法：
+
+```powershell
+$env:GHCUP_INSTALL_BASE_PREFIX = $env:USERPROFILE/sdk
+```
+
+或使用系统设置添加该环境变量。
+
+**Linux、FreeBSD、macOS 用户**:
+
+可以在终端使用如下方法：
+
+```bash
+export GHCUP_INSTALL_BASE_PREFIX=$HOME/sdk
+```
+
+还可以将上述内容写入 `~/.profile` 等文件中，具体可以参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。
+
+### MSYS2 设置
+
+对于 Windows 用户，如果系统中已经安装了 MSYS2 环境，则可以使用 `GHCUP_MSYS2` 来指定你想要 GHCup 使用的 MSYS2 环境。
+如果不指定使用的 MSYS2 环境，则会默认新安装一个 MSYS2 环境，并且使用新安装的 MSYS2 环境。
+
+详细内容可以参考 [GHCup env-variables](https://www.haskell.org/ghcup/guide/#env-variables)。

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -100,7 +100,7 @@ url-source:
 
 ```yaml
 url-source:
-  OwnSource: '{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.8.yaml'
+  OwnSource: {{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.8.yaml
 ```
 
 </CodeBlock>

--- a/contents/ghcup.mdx
+++ b/contents/ghcup.mdx
@@ -74,7 +74,7 @@ url-source:
 
 ```yaml
 url-source:
-  OwnSource: "{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.6.yaml"
+  OwnSource: "{{http_protocol}}{{mirror}}/yaml/ghcup/data/ghcup-0.0.8.yaml"
 ```
 
 </CodeBlock>
@@ -107,7 +107,7 @@ curl --proto '=https' --tlsv1.2 -LsSf https://{{mirror}}/script/install.sh | arc
 
 这可能是由于本机 ghcup 版本与配置文件版本不匹配造成。
 ghcup 于 0.1.15.1 版本前使用 0.0.4 版本的配置文件，此版本及之后的版本使用 0.0.5+ 版本的配置文件。
-请尝试将 `config.yaml` 中的 `ghcup-0.0.6.yaml` 改为 `ghcup-0.0.4.yaml` （抑或反之）后重试。
+请尝试将 `config.yaml` 中的 `ghcup-0.0.8.yaml` 改为 `ghcup-0.0.4.yaml` （抑或反之）后重试。
 
 请注意，ghcup 上游倾向于仅更新最新版本配置文件中的内容，当版本发生变化后请及时更新配置文件版本。
 

--- a/contents/hackage.mdx
+++ b/contents/hackage.mdx
@@ -58,7 +58,7 @@ remote-repo: mirror:{{http_protocol}}{{mirror}}
 
 注意，此处的注释是两条短线`--`.
 
-再执行`cabal v2-update`, 即可使用`cabal`安装包了。
+再执行`cabal update`, 即可使用`cabal`安装包了。
 
 ## 在 stack 中使用
 

--- a/contents/hackage.mdx
+++ b/contents/hackage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hackage 软件仓库镜像使用帮助
-cname: "hackage"
+cname: 'hackage'
 ---
 
 ## 在 cabal 中初次使用

--- a/contents/hackage.mdx
+++ b/contents/hackage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hackage 软件仓库镜像使用帮助
-cname: 'hackage'
+cname: "hackage"
 ---
 
 ## 在 cabal 中初次使用
@@ -44,6 +44,7 @@ repository hackage.haskell.org
 ```
 remote-repo: hackage.haskell.org:http://hackage.haskell.org/packages/archive
 ```
+
 注释掉，改为
 
 <CodeBlock>
@@ -57,11 +58,38 @@ remote-repo: mirror:{{http_protocol}}{{mirror}}
 
 注意，此处的注释是两条短线`--`.
 
-再执行`cabal update`, 即可使用`cabal`安装包了。
+再执行`cabal v2-update`, 即可使用`cabal`安装包了。
 
 ## 在 stack 中使用
 
 本镜像推荐与[Stackage 镜像](/stackage/)配合使用。
+
+### stack 大于等于 v2.9.3
+
+修改`~/.stack/config.yaml`, 加上：
+
+<CodeBlock>
+
+```yaml
+package-index:
+  download-prefix: {{http_protocol}}{{mirror}}/
+  hackage-security:
+    keyids:
+      - 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+      - 1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+      - 280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833
+      - 2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201
+      - 2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3
+      - 51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+      - 772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d
+      - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
+      - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+    key-threshold: 3 # number of keys required
+    # ignore expiration date, see https://github.com/commercialhaskell/stack/pull/4614
+    ignore-expiry: no
+```
+
+</CodeBlock>
 
 ### stack 大于等于 v2.1.1
 


### PR DESCRIPTION
fix #157

- 添加对于 stack >= v2.9.3 的配置方法
- 对于 GHCup 中 USTC 镜像连接进行修改
  USTC 镜像对于 GHCup 的同步方式与 NJU 和 STJUG 镜像都不同，不应该使用相同的替换方式，所以使用原链接替代