### PR TITLE
使用国内镜像源更新Docker GPG密钥下载地址

### DIFF
--- a/contents/docker-ce.mdx
+++ b/contents/docker-ce.mdx
@@ -64,7 +64,7 @@ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do
 
 ```bash
 {{sudo}}install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/{{deb_release}}/gpg | {{sudo}}gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL https://{{mirror}}}/linux/{{deb_release}}/gpg | {{sudo}}gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{http_protocol}}{{mirror}}/linux/{{deb_release}} \


### PR DESCRIPTION
## 描述

此PR更新了脚本中的Docker GPG密钥下载地址，以使用国内镜像源，解决由于网络访问限制导致的下载失败问题。

## 变更

将Docker GPG密钥的下载地址从`https://download.docker.com`更改为`https://{{mirror}}`。

