### PR TITLE
contents(crates): prefer `config.toml` format

### DIFF
--- a/contents/crates.io-index.git.mdx
+++ b/contents/crates.io-index.git.mdx
@@ -3,7 +3,7 @@ title: Rust crates.io 索引镜像使用帮助
 cname: 'crates.io-index.git'
 ---
 
-编辑 `$CARGO_HOME/config` 文件，添加以下内容：
+编辑 `$CARGO_HOME/config.toml` 文件，添加以下内容：
 
 <CodeBlock>
 
@@ -17,7 +17,9 @@ registry = "{{http_protocol}}{{mirror}}"
 
 </CodeBlock>
 
-注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`
+注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`。
+
+注：cargo 仍会尝试读取不带 `.toml` 扩展名的配置文件（即 `$CARGO_HOME/config`），但从 1.39 版本起，cargo 引入了对 `.toml` 扩展名的支持，并将其设为首选格式。请根据使用的 cargo 版本选择适当的配置文件名。
 
 在 Linux 环境可以使用下面的命令完成：
 
@@ -26,7 +28,7 @@ registry = "{{http_protocol}}{{mirror}}"
 ```bash
 mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
 [source.crates-io]
 replace-with = 'mirror'
 

--- a/contents/crates.io-index.mdx
+++ b/contents/crates.io-index.mdx
@@ -4,7 +4,7 @@ cname: 'crates.io-index'
 disable_https_select: true
 ---
 
-编辑 `$CARGO_HOME/config` 文件，添加以下内容：
+编辑 `$CARGO_HOME/config.toml` 文件，添加以下内容：
 
 <CodeBlock>
 
@@ -20,7 +20,9 @@ registry = "sparse+{{http_protocol}}{{mirror}}/"
 
 注：`sparse+` 表示在使用稀疏索引，链接末尾的 `/` 不能缺少。
 
-注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`
+注：`$CARGO_HOME`：在 Windows 系统默认为：`%USERPROFILE%\.cargo`，在类 Unix 系统默认为：`$HOME/.cargo`。
+
+注：cargo 仍会尝试读取不带 `.toml` 扩展名的配置文件（即 `$CARGO_HOME/config`），但从 1.39 版本起，cargo 引入了对 `.toml` 扩展名的支持，并将其设为首选格式。请根据使用的 cargo 版本选择适当的配置文件名。
 
 在 Linux 环境可以使用下面的命令完成：
 
@@ -29,7 +31,7 @@ registry = "sparse+{{http_protocol}}{{mirror}}/"
 ```bash
 mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
 [source.crates-io]
 replace-with = 'mirror'
 


### PR DESCRIPTION
Cargo now recommends using configuration files with the `.toml` extension (see: [The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure)). The changes should be introduced to the help documentation.