### PR TITLE
contents(FreeBSD): Add usage information for poudriere build system

### DIFF
--- a/contents/FreeBSD-pkg.mdx
+++ b/contents/FreeBSD-pkg.mdx
@@ -1,6 +1,6 @@
 ---
 title: FreeBSD pkg 镜像使用帮助
-cname: 'FreeBSD-pkg'
+cname: "FreeBSD-pkg"
 ---
 
 本镜像收录了自 FreeBSD 10 以后的版本，包括 quarterly 和滚动更新的 latest 仓库。
@@ -8,6 +8,8 @@ cname: 'FreeBSD-pkg'
 FreeBSD 9 以前的版本不支持新的 pkg 包管理器（pkgng），请升级到新版。
 
 ## 使用方法
+
+### FreeBSD pkg
 
 FreeBSD pkg 包管理器的官方源配置是 `/etc/pkg/FreeBSD.conf` ，请先检查该文件内容。注意其中的 `url` 参数配置了官方仓库的地址，我们需要把它替换为镜像站的地址。
 
@@ -27,3 +29,23 @@ FreeBSD: {
 
 注：使用 HTTPS 可以有效避免国内运营商的缓存劫持，但需要事先安装 `security/ca_root_nss` 软件包。
 
+### Ports Collection & Poudriere
+
+如果使用 [poudriere](https://github.com/freebsd/poudriere) 构建 `ports` 软件包，可以更改 `/usr/local/etc/poudriere.conf +374`，使用镜像站来获取二进制软件包。
+
+<CodeBlock>
+```
+# Set to always attempt to fetch packages or dependencies before building.
+# XXX: This is subject to change
+# Default: off; requires -b <branch> for bulk or testport.
+# PACKAGE_FETCH_BRANCH=latest
+# The branch will be appended to the URL:
+PACKAGE_FETCH_URL={{http_protocol}}{{mirror}}/\${ABI}
+```
+</CodeBlock>
+
+同样，使用 HTTPS 需要 `security/ca_root_nss`。
+
+更改后，运行 `poudriere bulk` 时会报错：`No SRV record found for the repo`，此报错无害，不影响使用。
+
+关于 `PACKAGE_FETCH_*` 的更多使用方法和配置可参考 `/usr/local/etc/poudriere.conf.sample`。


### PR DESCRIPTION
[Poudriere](https://github.com/freebsd/poudriere) 是 FreeBSD 官方的构建系统，可以用来批量构建 `ports` 中的软件。

对于指定的包，例如`rust` `node-*` `llvm` 这种用户自编译带来性能提升不大的软件，Poudriere 可以使用`PACKAGE_FETCH_*` 来获取二进制包。

我增加了配置 Poudriere 让其使用镜像站的方法。