### PR TITLE
contents(docker-ce): fedora: sync with official doc

### DIFF
--- a/contents/docker-ce.mdx
+++ b/contents/docker-ce.mdx
@@ -109,7 +109,7 @@ echo \
 <CodeBlock>
 ```bash
 {{sudo}}dnf -y install dnf-plugins-core
-{{sudo}}dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+{{sudo}}dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 {{sudo}}sed -i 's+https://download.docker.com+{{http_protocol}}{{mirror}}+' /etc/yum.repos.d/docker-ce.repo
 ```
 


### PR DESCRIPTION
Fedora 41 根据 MirrorZ 文档操作报错，查询官方文档发现 Fedora 需要使用 `dnf-3`

```bash
[root@master ~]# dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments.
[root@master ~]# dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
Adding repo from: https://download.docker.com/linux/fedora/docker-ce.repo
[root@master ~]# cat /etc/yum.repos.d/docker-ce.repo
[docker-ce-stable]
name=Docker CE Stable - $basearch
baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
enabled=1
......
```

See https://docs.docker.com/engine/install/fedora/