### PR TITLE
contents(rustup): Modify env definitions to .bashrc file

### DIFF
--- a/contents/rustup.mdx
+++ b/contents/rustup.mdx
@@ -34,8 +34,8 @@ env RUSTUP_DIST_SERVER={{http_protocol}}{{mirror}} rustup install nightly-YYYY-m
 
 ```bash
 # for bash
-echo 'export RUSTUP_UPDATE_ROOT={{http_protocol}}{{mirror}}/rustup' >> ~/.bash_profile
-echo 'export RUSTUP_DIST_SERVER={{http_protocol}}{{mirror}}' >> ~/.bash_profile
+echo 'export RUSTUP_UPDATE_ROOT={{http_protocol}}{{mirror}}/rustup' >> ~/.bashrc
+echo 'export RUSTUP_DIST_SERVER={{http_protocol}}{{mirror}}' >> ~/.bashrc
 # for fish
 echo 'set -x RUSTUP_UPDATE_ROOT {{http_protocol}}{{mirror}}/rustup' >> ~/.config/fish/config.fish
 echo 'set -x RUSTUP_DIST_SERVER {{http_protocol}}{{mirror}}' >> ~/.config/fish/config.fish


### PR DESCRIPTION
基于以下观察：
1. 大多数发行版习惯于在 .profile 里 source .bashrc （https://github.com/mirrorz-org/mirrorz-help/issues/139#issuecomment-1951316017 ）
2. Debian 等发行版更倾向于使用 .profile 而非 .bash_profile，创建 .bash_profile 会破坏发行版原有设计 （https://github.com/mirrorz-org/mirrorz-help/issues/139#issuecomment-3036813776 ）

注：rustup-init 在安装 rust 时若勾选了设置环境变量，会同时写 .profile 和 .bashrc，内容都是 `. "$HOME/.cargo/env"`

该 PR 并不关闭 #139，因为 homebrew 等镜像的帮助文档依然存在写入  .bash_profile 的问题，需再针对 macOS 进行分析