### PR TITLE
contents(nix-channels): add priority settings, bump channel version

### DIFF
--- a/contents/nix-channels.mdx
+++ b/contents/nix-channels.mdx
@@ -52,6 +52,28 @@ cname: 'nix-channels'
 
     </CodeBlock>
 
+  Nix 2.4 及之后的版本可以在 substituter 链接参数中指定优先级 (1~100)：
+
+    <CodeBlock>
+
+    ```nix
+    nix.settings.substituters = [ "{{http_protocol}}{{mirror}}/store?priority=10" ];
+    ```
+
+    </CodeBlock>
+
+  查询 substituter 默认优先级：
+
+  <CodeBlock>
+  
+  ```shell
+  curl {{http_protocol}}{{mirror}}/store/nix-cache-info
+  ```
+
+  </CodeBlock>
+
+  一般情况下，镜像的默认优先级为 40，与 cache.nixos.org 保持一致。
+
 #### 临时使用
 
 在安装 NixOS 时临时使用：
@@ -98,10 +120,9 @@ nix-channel --update
     {
       title: '系统版本',
       items: [
-        ['22.11', { version: '22.11' }],
+        ['25.05', { version: '25.05' }],
+        ['24.11', { version: '24.11' }],
         ['unstable', { version: 'unstable' }],
-        ['22.05', { version: '22.05' }],
-        ['21.11', { version: '21.11' }],
       ]
     }
   ]}


### PR DESCRIPTION
Nix 2.4 (2021-11-01) or later supports overriding substituter priority (See https://nix.dev/manual/nix/latest/release-notes/rl-2.4.html).

> The priority of substituters can now be overridden using the priority substituter setting (e.g. --substituters 'http://cache.nixos.org?priority=100 daemon?priority=10').

This PR is to avoid ambiguity when using multiple substituters (esp. mirrors from mirrorz help page).