### PR TITLE
fix(#263): single source of truth and one-way data flow

### DIFF
--- a/src/components/mdx-components/enhanced-codeblock/index.tsx
+++ b/src/components/mdx-components/enhanced-codeblock/index.tsx
@@ -73,7 +73,7 @@ function CodeBlock({
 
   const finalCode = useRenderCode(templateId, variableState, isHttpProtocol);
 
-  const codeBlockMenu = menus.length > 0 && <CodeBlockMenu menus={menus} dispatch={setVariableState} />;
+  const codeBlockMenu = menus.length > 0 && <CodeBlockMenu menus={menus} variableState={variableState} dispatch={setVariableState} />;
 
   if (enableQuickSetup && filepath) {
     return (

--- a/src/components/mdx-components/enhanced-codeblock/menus.tsx
+++ b/src/components/mdx-components/enhanced-codeblock/menus.tsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import IconChevronUpDown from '../../icons/chevron-up-down';
-import { memo, useState, useEffect } from 'react';
+import { memo } from 'react';
 import Switch from '../../form/checkbox';
 
 export type MenuValue = Record<string, string | boolean>;
@@ -106,58 +106,37 @@ const styles = stylex.create({
 
 interface CodeBlockMenuProps {
   menus: InputType[],
-  dispatch: React.Dispatch<MenuValue>
+  variableState: MenuValue,
+  dispatch: React.Dispatch<React.SetStateAction<MenuValue>>
 }
 
-function CodeBlockMenu({ menus, dispatch }: CodeBlockMenuProps) {
-  const [chosenValues, setChosenValues] = useState(menus.map((entry) => (
-    'items' in entry
-      ? 0 as number
-      : ('trueValue' in entry ? entry.defaultValue : entry.defaultValue || '')
-  )));
-  useEffect(() => {
-    const newValue = Object.values(chosenValues).reduce<MenuValue>((acc, chosen, menuIndex) => {
-      const menu = menus[menuIndex];
-      let value: MenuValue;
-      if ('items' in menu) {
-        value = menu.items[chosen as number][1];
-      } else if ('trueValue' in menu) {
-        const boolVal = chosen as boolean;
-        value = { [menu.name]: boolVal ? menu.trueValue : menu.falseValue };
-      } else {
-        value = { [menu.name]: chosen as string };
-      }
-      return {
-        ...acc,
-        ...value
-      };
-    }, {});
-    dispatch(newValue);
-  }, [chosenValues, dispatch, menus]);
-
+function CodeBlockMenu({ menus, variableState, dispatch }: CodeBlockMenuProps) {
   const handleChange: React.ChangeEventHandler<HTMLSelectElement | HTMLInputElement> = (e) => {
     const { name, value } = e.currentTarget;
     const menuIndex = Number.parseInt(name, 10);
-    const itemValue = e.currentTarget instanceof HTMLInputElement ? value : Number.parseInt(value, 10);
-    setChosenValues(prev => {
-      const newValues = [...prev];
-      newValues[menuIndex] = itemValue;
-      return newValues;
-    });
+    const menu = menus[menuIndex];
+
+    let partial: MenuValue;
+    if ('items' in menu) {
+      partial = menu.items[Number.parseInt(value, 10)][1];
+    } else {
+      partial = { [menu.name]: value };
+    }
+    dispatch(prev => ({ ...prev, ...partial }));
   };
 
   const handleSwitchChange = (menuIndex: number) => () => {
-    setChosenValues(prev => {
-      const newValues = [...prev];
-      newValues[menuIndex] = !newValues[menuIndex];
-      return newValues;
-    });
+    const menu = menus[menuIndex] as BooleanInput;
+    dispatch(prev => ({
+      ...prev,
+      [menu.name]: prev[menu.name] === menu.trueValue ? menu.falseValue : menu.trueValue
+    }));
   };
 
   return (
     <div {...stylex.props(styles.container)}>
       {menus.map((menu, menuIndex) => (
-        <div {...stylex.props(styles.menu)} key={menu.title}>
+        <div key={menu.title} {...stylex.props(styles.menu)}>
           {'items' in menu
             ? <>
               <span>{menu.title}</span>
@@ -177,7 +156,7 @@ function CodeBlockMenu({ menus, dispatch }: CodeBlockMenuProps) {
             : ('trueValue' in menu
               ? (
                 <Switch
-                  checked={chosenValues[menuIndex] as boolean}
+                  checked={variableState[menu.name] === menu.trueValue}
                   onChange={handleSwitchChange(menuIndex)}
                   label={menu.title}
                 />

--- a/src/components/mdx-components/globalMenu/index.tsx
+++ b/src/components/mdx-components/globalMenu/index.tsx
@@ -1,8 +1,8 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import type { Menu, MenuValue } from '../enhanced-codeblock/menus';
 import CodeBlockMenu from '../enhanced-codeblock/menus';
 import { EMPTY_ARRAY } from '../../../lib/client/constant';
-import { useSetPageGlobalVariable } from '@/contexts/page-global-variable';
+import { usePageGlobalVariable, useSetPageGlobalVariable } from '@/contexts/page-global-variable';
 
 interface GlobalMenuProps {
   menus?: Menu[],
@@ -14,16 +14,18 @@ function GlobalMenu({
   menus = EMPTY_ARRAY,
   id
 }: GlobalMenuProps) {
+  const pageGlobalVars = usePageGlobalVariable();
   const setPageGlobalVars = useSetPageGlobalVariable();
-  const setVariableState = (value: MenuValue) => {
-    setPageGlobalVars((prev) => ({
-      ...prev,
-      [id]: value
-    }));
-  };
+  const variableState = pageGlobalVars[id] ?? {};
+  const dispatch: React.Dispatch<React.SetStateAction<MenuValue>> = useCallback((action) => {
+    setPageGlobalVars((prev) => {
+      const newValue = typeof action === 'function' ? action(prev[id] ?? {}) : action;
+      return { ...prev, [id]: newValue };
+    });
+  }, [id, setPageGlobalVars]);
   return (
     <div>
-      <CodeBlockMenu menus={menus} dispatch={setVariableState} />
+      <CodeBlockMenu menus={menus} variableState={variableState} dispatch={dispatch} />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #263, properly this time.

- Do not let code block menus owns any state
  - There should only be single source of truth, `variableState` from code block root. Any operations of code block menus should be operating root state directly, not mutate then watch report.
  - By `useEffect` watching internal state and report, this breaks React one way data flow. The PR fixes that.